### PR TITLE
fix(projects.service): use plainToInstance instead of deprecated plainToClass

### DIFF
--- a/backend/src/projects/projects.service.ts
+++ b/backend/src/projects/projects.service.ts
@@ -19,7 +19,7 @@ import { EventsService } from "../events/events.service";
 import { LogsService } from "../logs/logs.service";
 import { TransactionsService } from "../transactions/transactions.service";
 import { FlowCliService } from "../flow/services/flow-cli.service";
-import { plainToClass } from "class-transformer";
+import { plainToInstance } from "class-transformer";
 import { StorageDataService } from '../flow/services/storage-data.service';
 import config from "../config";
 
@@ -149,7 +149,7 @@ export class ProjectsService {
             if (project.gateway) {
                 const { address, port } = project.gateway;
                 const pingable = project.isOfficialNetwork() || await FlowGatewayService.isPingable(address, port)
-                return plainToClass(Project, { ...project, pingable });
+                return plainToInstance(Project, { ...project, pingable });
             } else {
                 return project
             }
@@ -165,7 +165,7 @@ export class ProjectsService {
         if (project.gateway) {
             const { port, address } = project.gateway;
             const pingable = project.isOfficialNetwork() || await FlowGatewayService.isPingable(address, port)
-            return plainToClass(Project, { ...project, pingable });
+            return plainToInstance(Project, { ...project, pingable });
         } else {
             return project;
         }


### PR DESCRIPTION
### Context

I was trying to start the project but the backend service just kept crashing.

I found out this was because of a breaking change in `class-transformer`, which was released in `0.4.1` (Not a big fan of their release management hehe...)

https://github.com/typestack/class-transformer/blob/develop/CHANGELOG.md#041-breaking-change---2021-11-20

### Work

I updated the import from `plainToClass` to `plainToInstance`.
