### PR TITLE
Simplify Flow tools startup logic

### DIFF
--- a/backend/src/blocks/blocks.service.ts
+++ b/backend/src/blocks/blocks.service.ts
@@ -26,7 +26,7 @@ export class BlocksService {
     });
   }
 
-  findLastBlock(): Promise<BlockEntity> {
+  findLastBlock(): Promise<BlockEntity | null> {
     return this.blockRepository
       .createQueryBuilder("block")
       .select()

--- a/backend/src/core/filters/http-exception.filter.ts
+++ b/backend/src/core/filters/http-exception.filter.ts
@@ -5,7 +5,7 @@ import {
   HttpException,
 } from "@nestjs/common";
 import { Response } from "express";
-import { ErrorResponse } from "@flowser/shared";
+import { ErrorResponse, FlowserError } from "@flowser/shared";
 
 @Catch(HttpException)
 export class HttpExceptionFilter implements ExceptionFilter {
@@ -16,10 +16,10 @@ export class HttpExceptionFilter implements ExceptionFilter {
 
     response.status(status).json(
       ErrorResponse.toJSON({
-        error: {
+        error: FlowserError.fromPartial({
           name: exception.name,
           message: exception.message,
-        },
+        }),
       })
     );
   }

--- a/backend/src/flow/services/aggregator.service.ts
+++ b/backend/src/flow/services/aggregator.service.ts
@@ -30,7 +30,7 @@ import { FlowAccountStorageService } from "./storage.service";
 import { AccountStorageService } from "../../accounts/services/storage.service";
 import {
   FlowCoreEventType,
-  GatewayStatus,
+  ServiceStatus,
   ManagedProcessState,
 } from "@flowser/shared";
 import {
@@ -160,7 +160,7 @@ export class FlowAggregatorService implements ProjectContextLifecycle {
     const gatewayStatus = await FlowGatewayService.getGatewayStatus(
       this.projectContext.gateway
     );
-    if (gatewayStatus !== GatewayStatus.GATEWAY_STATUS_ONLINE) {
+    if (gatewayStatus !== ServiceStatus.SERVICE_STATUS_ONLINE) {
       return;
     }
 

--- a/backend/src/flow/services/aggregator.service.ts
+++ b/backend/src/flow/services/aggregator.service.ts
@@ -157,7 +157,7 @@ export class FlowAggregatorService implements ProjectContextLifecycle {
     if (!this.projectContext) {
       return;
     }
-    const gatewayStatus = await FlowGatewayService.getGatewayStatus(
+    const gatewayStatus = await FlowGatewayService.getApiStatus(
       this.projectContext.gateway
     );
     if (gatewayStatus !== ServiceStatus.SERVICE_STATUS_ONLINE) {

--- a/backend/src/flow/services/aggregator.service.ts
+++ b/backend/src/flow/services/aggregator.service.ts
@@ -28,7 +28,11 @@ import { ProjectContextLifecycle } from "../utils/project-context";
 import { ProjectEntity } from "../../projects/entities/project.entity";
 import { FlowAccountStorageService } from "./storage.service";
 import { AccountStorageService } from "../../accounts/services/storage.service";
-import { FlowCoreEventType, ManagedProcessState } from "@flowser/shared";
+import {
+  FlowCoreEventType,
+  GatewayStatus,
+  ManagedProcessState,
+} from "@flowser/shared";
 import {
   ProcessManagerEvent,
   ProcessManagerService,
@@ -47,7 +51,12 @@ type BlockData = {
   events: ExtendedFlowEvent[];
 };
 
-export type FlowTransactionWithStatus = FlowTransaction & {
+type UnprocessedBlockInfo = {
+  nextBlockHeightToProcess: number;
+  latestUnprocessedBlockHeight: number;
+};
+
+type FlowTransactionWithStatus = FlowTransaction & {
   status: FlowTransactionStatus;
 };
 
@@ -136,8 +145,10 @@ export class FlowAggregatorService implements ProjectContextLifecycle {
   }
 
   async getTotalBlocksToProcess() {
-    const { startBlockHeight, endBlockHeight } = await this.getBlockRange();
-    return endBlockHeight - startBlockHeight;
+    const { nextBlockHeightToProcess, latestUnprocessedBlockHeight } =
+      await this.getUnprocessedBlocksInfo();
+
+    return latestUnprocessedBlockHeight - (nextBlockHeightToProcess - 1);
   }
 
   // TODO(milestone-x): Next interval shouldn't start before this function resolves
@@ -146,10 +157,10 @@ export class FlowAggregatorService implements ProjectContextLifecycle {
     if (!this.projectContext) {
       return;
     }
-    if (
-      this.projectContext.shouldRunEmulator() &&
-      !this.emulatorProcess?.isRunning()
-    ) {
+    const gatewayStatus = await FlowGatewayService.getGatewayStatus(
+      this.projectContext.gateway
+    );
+    if (gatewayStatus !== GatewayStatus.GATEWAY_STATUS_ONLINE) {
       return;
     }
 
@@ -158,55 +169,49 @@ export class FlowAggregatorService implements ProjectContextLifecycle {
       await this.processDefaultAccounts();
     }
 
-    const { startBlockHeight, endBlockHeight } = await this.getBlockRange();
-    const hasBlocksToProcess = startBlockHeight <= endBlockHeight;
+    const { nextBlockHeightToProcess, latestUnprocessedBlockHeight } =
+      await this.getUnprocessedBlocksInfo();
+    const hasBlocksToProcess =
+      nextBlockHeightToProcess <= latestUnprocessedBlockHeight;
+
     if (!hasBlocksToProcess) {
       return;
     }
 
     try {
-      await this.processBlocksWithinHeightRange(
-        startBlockHeight,
-        endBlockHeight
-      );
+      for (
+        let height = nextBlockHeightToProcess;
+        height <= latestUnprocessedBlockHeight;
+        height++
+      ) {
+        this.logger.debug(`Processing block: ${height}`);
+        // Blocks must be processed in sequential order (not in parallel)
+        // because objects on subsequent blocks can reference objects from previous blocks
+        // (e.g. a transaction may reference an account from previous block)
+        await this.processBlockWithHeight(height);
+      }
     } catch (e) {
       return this.logger.debug(`failed to fetch block data: ${e}`);
     }
   }
 
-  async getBlockRange() {
+  private async getUnprocessedBlocksInfo(): Promise<UnprocessedBlockInfo> {
     const [lastStoredBlock, latestBlock] = await Promise.all([
       this.blockService.findLastBlock(),
       this.flowGatewayService.getLatestBlock(),
     ]);
-
-    // user can specify (on a project level) what is the starting block height
-    // if user provides no specification, the latest block height is used
-    const initialStartBlockHeight =
-      !this.projectContext.isStartBlockHeightDefined()
-        ? latestBlock.height
-        : this.projectContext.startBlockHeight;
-
-    // fetch from last stored block (if there are already blocks in the database)
-    const startBlockHeight = lastStoredBlock
+    const nextBlockHeightToProcess = lastStoredBlock
       ? lastStoredBlock.height + 1
-      : initialStartBlockHeight;
-    const endBlockHeight = latestBlock.height;
+      : this.projectContext.startBlockHeight;
+    const latestUnprocessedBlockHeight = latestBlock.height;
 
-    return { startBlockHeight, endBlockHeight };
+    return {
+      nextBlockHeightToProcess,
+      latestUnprocessedBlockHeight,
+    };
   }
 
-  public async processBlocksWithinHeightRange(
-    fromHeight: number,
-    toHeight: number
-  ) {
-    for (let height = fromHeight; height <= toHeight; height++) {
-      this.logger.debug(`fetching block: ${height}`);
-      await this.processBlockWithHeight(height);
-    }
-  }
-
-  async processBlockWithHeight(height: number) {
+  private async processBlockWithHeight(height: number) {
     const dataSource = await getDataSourceInstance();
     const queryRunner = dataSource.createQueryRunner();
 
@@ -233,13 +238,13 @@ export class FlowAggregatorService implements ProjectContextLifecycle {
     }
   }
 
-  subscribeTxStatusUpdates(transactions: FlowTransactionWithStatus[]) {
+  private subscribeTxStatusUpdates(transactions: FlowTransactionWithStatus[]) {
     transactions.forEach((transaction) => {
       this.flowSubscriptionService.addTransactionSubscription(transaction.id);
     });
   }
 
-  async storeBlockData(data: BlockData) {
+  private async storeBlockData(data: BlockData) {
     // TODO(milestone-3): Transaction references previous block in referenceBlockId field. Why? Previously we used this field to indicate which block contained some transaction.
     // Docs say: referenceBlockId = A reference to the block used to calculate the expiry of this transaction.
     // https://developers.flow.com/tools/fcl-js/reference/api#transactionobject
@@ -272,7 +277,7 @@ export class FlowAggregatorService implements ProjectContextLifecycle {
     return Promise.all([blockPromise, transactionPromises, eventPromises]);
   }
 
-  public async getBlockData(height: number): Promise<BlockData> {
+  private async getBlockData(height: number): Promise<BlockData> {
     const block = await this.flowGatewayService.getBlockByHeight(height);
     const collections = await Promise.all(
       block.collectionGuarantees.map(async (guarantee) =>
@@ -322,7 +327,7 @@ export class FlowAggregatorService implements ProjectContextLifecycle {
     };
   }
 
-  async processEvents(events: FlowEvent[]) {
+  private async processEvents(events: FlowEvent[]) {
     // Process new accounts first, so other events can reference them.
     const accountCreatedEvents = events.filter(
       (event) => event.type === FlowCoreEventType.ACCOUNT_CREATED
@@ -349,7 +354,7 @@ export class FlowAggregatorService implements ProjectContextLifecycle {
     );
   }
 
-  async handleEvent(event: FlowEvent) {
+  private async handleEvent(event: FlowEvent) {
     const { data, type } = event;
     this.logger.debug(`handling event: ${type} ${JSON.stringify(data)}`);
     const address = ensurePrefixedAddress(data.address);
@@ -369,7 +374,7 @@ export class FlowAggregatorService implements ProjectContextLifecycle {
     }
   }
 
-  async handleTransactionCreated(
+  private async handleTransactionCreated(
     block: FlowBlock,
     transaction: FlowTransaction,
     status: FlowTransactionStatus
@@ -384,7 +389,7 @@ export class FlowAggregatorService implements ProjectContextLifecycle {
     ]);
   }
 
-  async storeNewAccountWithContractsAndKeys(address: string) {
+  private async storeNewAccountWithContractsAndKeys(address: string) {
     const flowAccount = await this.flowGatewayService.getAccount(address);
     const unSerializedAccount = AccountEntity.create(flowAccount);
     if (
@@ -412,7 +417,7 @@ export class FlowAggregatorService implements ProjectContextLifecycle {
     ]);
   }
 
-  async updateStoredAccountKeys(address: string) {
+  private async updateStoredAccountKeys(address: string) {
     const flowAccount = await this.flowGatewayService.getAccount(address);
     await Promise.all([
       this.accountService.markUpdated(address),
@@ -425,7 +430,7 @@ export class FlowAggregatorService implements ProjectContextLifecycle {
     ]);
   }
 
-  async updateStoredAccountContracts(address: string) {
+  private async updateStoredAccountContracts(address: string) {
     const flowAccount = await this.flowGatewayService.getAccount(address);
     const account = AccountEntity.create(flowAccount);
     const newContracts = Object.keys(flowAccount.contracts).map((name) =>
@@ -445,7 +450,7 @@ export class FlowAggregatorService implements ProjectContextLifecycle {
     ]);
   }
 
-  async updateAccountsStorage() {
+  private async updateAccountsStorage() {
     const allAddresses = await this.accountService.findAllAddresses();
     this.logger.debug(
       `Processing storages for accounts: ${allAddresses.join(", ")}`
@@ -455,7 +460,7 @@ export class FlowAggregatorService implements ProjectContextLifecycle {
     );
   }
 
-  async processAccountStorage(address: string) {
+  private async processAccountStorage(address: string) {
     const { privateItems, publicItems, storageItems } =
       await this.flowStorageService.getAccountStorage(address);
     return this.accountStorageService.updateAccountStorage(address, [
@@ -465,14 +470,14 @@ export class FlowAggregatorService implements ProjectContextLifecycle {
     ]);
   }
 
-  async isServiceAccountProcessed() {
+  private async isServiceAccountProcessed() {
     const serviceAccountAddress = ensurePrefixedAddress(
       this.configService.getServiceAccountAddress()
     );
     return this.accountService.accountExists(serviceAccountAddress);
   }
 
-  async processDefaultAccounts() {
+  private async processDefaultAccounts() {
     const dataSource = await getDataSourceInstance();
     const queryRunner = dataSource.createQueryRunner();
 
@@ -491,7 +496,7 @@ export class FlowAggregatorService implements ProjectContextLifecycle {
     }
   }
 
-  getDefaultAccountsAddresses() {
+  private getDefaultAccountsAddresses() {
     const serviceAccountAddress = ensurePrefixedAddress(
       this.configService.getServiceAccountAddress()
     );

--- a/backend/src/flow/services/config.service.ts
+++ b/backend/src/flow/services/config.service.ts
@@ -73,8 +73,8 @@ export class FlowConfigService implements ProjectContextLifecycle {
   }
 
   onExitProjectContext() {
-    this.detachListeners();
     this.projectContext = undefined;
+    this.detachListeners();
   }
 
   public async reload() {

--- a/backend/src/flow/services/dev-wallet.service.ts
+++ b/backend/src/flow/services/dev-wallet.service.ts
@@ -3,6 +3,8 @@ import { ProjectContextLifecycle } from "../utils/project-context";
 import { ProjectEntity } from "../../projects/entities/project.entity";
 import { ProcessManagerService } from "../../processes/process-manager.service";
 import { ManagedProcessEntity } from "../../processes/managed-process.entity";
+import { DevWallet, ServiceStatus } from "@flowser/shared";
+import * as http from "http";
 
 @Injectable()
 export class FlowDevWalletService implements ProjectContextLifecycle {
@@ -13,18 +15,17 @@ export class FlowDevWalletService implements ProjectContextLifecycle {
 
   async onEnterProjectContext(project: ProjectEntity) {
     this.projectContext = project;
-    if (this.projectContext.shouldRunDevWallet()) {
+    const walletApiStatus = await FlowDevWalletService.getApiStatus(
+      this.projectContext.devWallet
+    );
+    if (walletApiStatus !== ServiceStatus.SERVICE_STATUS_ONLINE) {
       await this.start();
     }
   }
 
   async onExitProjectContext() {
-    if (this.projectContext?.shouldRunDevWallet()) {
-      await this.processManagerService.stop(FlowDevWalletService.processId);
-      this.processManagerService
-        .get(FlowDevWalletService.processId)
-        ?.clearLogs();
-    }
+    await this.processManagerService.stop(FlowDevWalletService.processId);
+    this.processManagerService.get(FlowDevWalletService.processId)?.clearLogs();
   }
 
   async start() {
@@ -44,5 +45,26 @@ export class FlowDevWalletService implements ProjectContextLifecycle {
       },
     });
     await this.processManagerService.start(devWalletProcess);
+  }
+
+  static async getApiStatus(devWallet: DevWallet): Promise<ServiceStatus> {
+    return new Promise((resolve) => {
+      const req = http
+        .get(
+          {
+            host: "localhost",
+            path: "/api/",
+            port: devWallet.port,
+          },
+          () => {
+            req.end();
+            return resolve(ServiceStatus.SERVICE_STATUS_ONLINE);
+          }
+        )
+        .on("error", (err) => {
+          req.end();
+          return resolve(ServiceStatus.SERVICE_STATUS_OFFLINE);
+        });
+    });
   }
 }

--- a/backend/src/flow/services/dev-wallet.service.ts
+++ b/backend/src/flow/services/dev-wallet.service.ts
@@ -24,7 +24,7 @@ export class FlowDevWalletService implements ProjectContextLifecycle {
   }
 
   async onExitProjectContext() {
-    await this.processManagerService.stop(FlowDevWalletService.processId);
+    await this.processManagerService.remove(FlowDevWalletService.processId);
     this.processManagerService.get(FlowDevWalletService.processId)?.clearLogs();
   }
 

--- a/backend/src/flow/services/emulator.service.ts
+++ b/backend/src/flow/services/emulator.service.ts
@@ -19,7 +19,7 @@ export class FlowEmulatorService implements ProjectContextLifecycle {
 
   async onEnterProjectContext(project: ProjectEntity) {
     this.projectContext = project;
-    const accessNodeStatus = await FlowGatewayService.getGatewayStatus(
+    const accessNodeStatus = await FlowGatewayService.getApiStatus(
       this.projectContext.gateway
     );
     if (accessNodeStatus !== ServiceStatus.SERVICE_STATUS_ONLINE) {

--- a/backend/src/flow/services/emulator.service.ts
+++ b/backend/src/flow/services/emulator.service.ts
@@ -29,7 +29,7 @@ export class FlowEmulatorService implements ProjectContextLifecycle {
 
   async onExitProjectContext() {
     this.projectContext = undefined;
-    await this.stop();
+    await this.processManagerService.remove(FlowEmulatorService.processId);
     this.processManagerService.get(FlowEmulatorService.processId)?.clearLogs();
   }
 
@@ -46,10 +46,6 @@ export class FlowEmulatorService implements ProjectContextLifecycle {
       },
     });
     await this.processManagerService.start(managedProcess);
-  }
-
-  async stop() {
-    await this.processManagerService.stop(FlowEmulatorService.processId);
   }
 
   private getFlags() {

--- a/backend/src/flow/services/emulator.service.ts
+++ b/backend/src/flow/services/emulator.service.ts
@@ -1,9 +1,14 @@
 import { Injectable, InternalServerErrorException } from "@nestjs/common";
-import { hashAlgorithmToJSON, signatureAlgorithmToJSON } from "@flowser/shared";
+import {
+  ServiceStatus,
+  hashAlgorithmToJSON,
+  signatureAlgorithmToJSON,
+} from "@flowser/shared";
 import { ProjectContextLifecycle } from "../utils/project-context";
 import { ProjectEntity } from "../../projects/entities/project.entity";
 import { ProcessManagerService } from "../../processes/process-manager.service";
 import { ManagedProcessEntity } from "../../processes/managed-process.entity";
+import { FlowGatewayService } from "./gateway.service";
 
 @Injectable()
 export class FlowEmulatorService implements ProjectContextLifecycle {
@@ -14,7 +19,10 @@ export class FlowEmulatorService implements ProjectContextLifecycle {
 
   async onEnterProjectContext(project: ProjectEntity) {
     this.projectContext = project;
-    if (this.projectContext.shouldRunEmulator()) {
+    const accessNodeStatus = await FlowGatewayService.getGatewayStatus(
+      this.projectContext.gateway
+    );
+    if (accessNodeStatus !== ServiceStatus.SERVICE_STATUS_ONLINE) {
       await this.start();
     }
   }

--- a/backend/src/flow/services/gateway.service.ts
+++ b/backend/src/flow/services/gateway.service.ts
@@ -6,7 +6,7 @@ import {
 import * as http from "http";
 import { ProjectContextLifecycle } from "../utils/project-context";
 import { ProjectEntity } from "../../projects/entities/project.entity";
-import { Gateway, GatewayStatus } from "@flowser/shared";
+import { Gateway, ServiceStatus } from "@flowser/shared";
 
 const fcl = require("@onflow/fcl");
 
@@ -170,7 +170,7 @@ export class FlowGatewayService implements ProjectContextLifecycle {
     return { ...account, address };
   }
 
-  static async getGatewayStatus(gateway: Gateway): Promise<GatewayStatus> {
+  static async getGatewayStatus(gateway: Gateway): Promise<ServiceStatus> {
     const { hostname, port } = new URL(gateway.restServerAddress);
     return new Promise((resolve) => {
       const req = http
@@ -186,14 +186,13 @@ export class FlowGatewayService implements ProjectContextLifecycle {
             // Ideally we should send a ping request to access API
             // but that endpoint isn't implemented on emulator side (afaik)
             // https://github.com/onflow/flow/blob/master/protobuf/flow/access/access.proto#L20
-            return resolve(GatewayStatus.GATEWAY_STATUS_ONLINE);
+            return resolve(ServiceStatus.SERVICE_STATUS_ONLINE);
           }
         )
         .on("error", (err) => {
           req.end();
-          return resolve(GatewayStatus.GATEWAY_STATUS_OFFLINE);
+          return resolve(ServiceStatus.SERVICE_STATUS_OFFLINE);
         });
-      return true;
     });
   }
 }

--- a/backend/src/flow/services/gateway.service.ts
+++ b/backend/src/flow/services/gateway.service.ts
@@ -170,7 +170,7 @@ export class FlowGatewayService implements ProjectContextLifecycle {
     return { ...account, address };
   }
 
-  static async getGatewayStatus(gateway: Gateway): Promise<ServiceStatus> {
+  static async getApiStatus(gateway: Gateway): Promise<ServiceStatus> {
     const { hostname, port } = new URL(gateway.restServerAddress);
     return new Promise((resolve) => {
       const req = http

--- a/backend/src/processes/process-manager.service.ts
+++ b/backend/src/processes/process-manager.service.ts
@@ -102,6 +102,15 @@ export class ProcessManagerService extends EventEmitter {
     await this.processLookupById.get(processId)?.stop();
   }
 
+  /**
+   * Stops the process and removes it from the process table.
+   * Process state won't be tracked anymore.
+   */
+  async remove(processId: string) {
+    await this.stop(processId);
+    this.processLookupById.delete(processId);
+  }
+
   async restart(processId: string) {
     const process = this.processLookupById.get(processId);
     if (!process) {

--- a/backend/src/projects/dto/dev-wallet-configuration.dto.ts
+++ b/backend/src/projects/dto/dev-wallet-configuration.dto.ts
@@ -1,6 +1,6 @@
 import { IsNotEmpty } from "class-validator";
 import { ApiProperty } from "@nestjs/swagger";
-import { DevWallet, Gateway, GatewayStatus } from "@flowser/shared";
+import { DevWallet, Gateway, ServiceStatus } from "@flowser/shared";
 
 export class DevWalletConfigurationDto implements DevWallet {
   @ApiProperty()

--- a/backend/src/projects/dto/dev-wallet-configuration.dto.ts
+++ b/backend/src/projects/dto/dev-wallet-configuration.dto.ts
@@ -1,12 +1,9 @@
 import { IsNotEmpty } from "class-validator";
 import { ApiProperty } from "@nestjs/swagger";
-import { DevWallet, Gateway, ServiceStatus } from "@flowser/shared";
+import { DevWallet } from "@flowser/shared";
 
 export class DevWalletConfigurationDto implements DevWallet {
   @ApiProperty()
   @IsNotEmpty()
   port: number;
-  @ApiProperty()
-  @IsNotEmpty()
-  run: boolean;
 }

--- a/backend/src/projects/dto/emulator-configuration.dto.ts
+++ b/backend/src/projects/dto/emulator-configuration.dto.ts
@@ -25,8 +25,6 @@ export class EmulatorConfigurationDto implements Emulator {
   @ApiProperty()
   restServerPort: number;
   @ApiProperty()
-  run: boolean;
-  @ApiProperty()
   scriptGasLimit: number;
   @ApiProperty()
   serviceHashAlgorithm: number;

--- a/backend/src/projects/dto/gateway-configuration.dto.ts
+++ b/backend/src/projects/dto/gateway-configuration.dto.ts
@@ -1,6 +1,6 @@
 import { IsNotEmpty } from "class-validator";
 import { ApiProperty } from "@nestjs/swagger";
-import { Gateway, GatewayStatus } from "@flowser/shared";
+import { Gateway, ServiceStatus } from "@flowser/shared";
 
 export class GatewayConfigurationDto implements Gateway {
   @ApiProperty()
@@ -13,5 +13,5 @@ export class GatewayConfigurationDto implements Gateway {
 
   @ApiProperty()
   @IsNotEmpty()
-  status: GatewayStatus;
+  status: ServiceStatus;
 }

--- a/backend/src/projects/entities/project.entity.ts
+++ b/backend/src/projects/entities/project.entity.ts
@@ -37,25 +37,13 @@ export class ProjectEntity extends PollingEntity {
   })
   emulator: Emulator | null;
 
-  // Blockchain data will be fetched from this block height
-  // Set this null to start fetching from the latest block
+  // User can specify (on a project level) the starting block height.
+  // Blockchain data will be fetched from this height value if set.
   @Column({ nullable: true })
   startBlockHeight: number | null = 0;
 
   hasGatewayConfiguration() {
     return this.gateway !== null;
-  }
-
-  isStartBlockHeightDefined() {
-    return this.startBlockHeight !== null;
-  }
-
-  shouldRunEmulator() {
-    return Boolean(this.emulator?.run);
-  }
-
-  shouldRunDevWallet() {
-    return Boolean(this.devWallet?.run);
   }
 
   toProto(): Project {

--- a/backend/src/projects/projects.service.ts
+++ b/backend/src/projects/projects.service.ts
@@ -94,16 +94,20 @@ export class ProjectsService {
     if (!this.currentProject.gateway) {
       throw new PreconditionFailedException("Gateway not configured");
     }
-    const gatewayStatus = await FlowGatewayService.getGatewayStatus(
+    const flowApiStatus = await FlowGatewayService.getApiStatus(
       this.currentProject.gateway
     );
+    const devWalletApiStatus = await FlowDevWalletService.getApiStatus(
+      this.currentProject.devWallet
+    );
     const totalBlocksToProcess =
-      gatewayStatus === ServiceStatus.SERVICE_STATUS_ONLINE
+      flowApiStatus === ServiceStatus.SERVICE_STATUS_ONLINE
         ? await this.flowAggregatorService.getTotalBlocksToProcess()
         : -1;
     return {
       totalBlocksToProcess,
-      gatewayStatus,
+      flowApiStatus,
+      devWalletApiStatus,
     };
   }
 
@@ -278,7 +282,7 @@ export class ProjectsService {
 
   private async setComputedFields(project: ProjectEntity) {
     if (project.hasGatewayConfiguration()) {
-      project.gateway.status = await FlowGatewayService.getGatewayStatus(
+      project.gateway.status = await FlowGatewayService.getApiStatus(
         project.gateway
       );
     }

--- a/backend/src/projects/projects.service.ts
+++ b/backend/src/projects/projects.service.ts
@@ -27,7 +27,7 @@ import {
   DevWallet,
   Emulator,
   Gateway,
-  GatewayStatus,
+  ServiceStatus,
   GetProjectStatusResponse,
   HashAlgorithm,
   Project,
@@ -98,7 +98,7 @@ export class ProjectsService {
       this.currentProject.gateway
     );
     const totalBlocksToProcess =
-      gatewayStatus === GatewayStatus.GATEWAY_STATUS_ONLINE
+      gatewayStatus === ServiceStatus.SERVICE_STATUS_ONLINE
         ? await this.flowAggregatorService.getTotalBlocksToProcess()
         : -1;
     return {

--- a/backend/src/projects/projects.service.ts
+++ b/backend/src/projects/projects.service.ts
@@ -246,11 +246,9 @@ export class ProjectsService {
         grpcServerAddress: `http://localhost:${grpcServerPort}`,
       }),
       devWallet: DevWallet.fromJSON({
-        run: true,
         port: 8701,
       }),
       emulator: Emulator.fromPartial({
-        run: true,
         verboseLogging: true,
         restServerPort,
         grpcServerPort,

--- a/frontend/src/components/sidebar/SideBar.module.scss
+++ b/frontend/src/components/sidebar/SideBar.module.scss
@@ -38,6 +38,11 @@
       -webkit-text-fill-color: transparent;
     }
 
+    .description {
+      color: $color-grey;
+      font-size: $font-size-small;
+    }
+
     .menuItem {
       display: flex;
       padding: $spacing-base * 0.6 0;

--- a/frontend/src/components/sidebar/SideBar.tsx
+++ b/frontend/src/components/sidebar/SideBar.tsx
@@ -131,9 +131,15 @@ export function SideBar({ toggled, toggleSidebar }: Sidebar): ReactElement {
           <div className={classes.menuDivider} />
           <span className={classes.menuSectionTitle}>PROCESSES</span>
           <div className={classes.processItemsWrapper}>
-            {processes.map((process) => (
-              <ManagedProcessItem key={process.id} process={process} />
-            ))}
+            {processes.length > 0 ? (
+              processes.map((process) => (
+                <ManagedProcessItem key={process.id} process={process} />
+              ))
+            ) : (
+              <span className={classes.description}>
+                No processes are running within Flowser
+              </span>
+            )}
           </div>
         </div>
         <div>

--- a/frontend/src/components/snapshot-dialog/SnapshotDialog.tsx
+++ b/frontend/src/components/snapshot-dialog/SnapshotDialog.tsx
@@ -39,12 +39,10 @@ export const SnapshotDialog: FC<SnapshotDialogProps> = ({ show, setShow }) => {
       onClose();
     } catch (e) {
       handleError(e);
-      if (!data?.project?.emulator?.run) {
-        toast(
-          "Make sure you are using the '--snapshot' flag when running emulator",
-          { duration: 4000 }
-        );
-      }
+      toast(
+        "Make sure you are using the '--snapshot' flag when running emulator",
+        { duration: 4000 }
+      );
     } finally {
       setLoading(false);
     }

--- a/frontend/src/components/table/Table.tsx
+++ b/frontend/src/components/table/Table.tsx
@@ -70,8 +70,8 @@ function Table<TData>({
   if (!isInitialLoading && data.length === 0) {
     return (
       <Message
-        title="It looks like there is nothing here."
-        description="No results"
+        title="No results"
+        description="It looks like there is nothing here."
       />
     );
   }

--- a/frontend/src/config/toast.ts
+++ b/frontend/src/config/toast.ts
@@ -4,6 +4,8 @@ export const toastOptions = {
     background: "#9BDEFA", // $blue
     color: "#363F53", // $table-line-background
     padding: "12px", // $spacing-base
-    maxWidth: "initial",
+    maxWidth: "400px",
+    maxHeight: "200px",
+    textOverflow: "ellipsis",
   },
 };

--- a/frontend/src/contexts/timeout-polling.context.tsx
+++ b/frontend/src/contexts/timeout-polling.context.tsx
@@ -8,7 +8,7 @@ import React, {
 } from "react";
 import { PollingEntity, PollingResponse } from "@flowser/shared";
 import { useQuery } from "react-query";
-import { useIsInitialLoad } from "../hooks/use-api";
+import { useGatewayStatus } from "../hooks/use-api";
 
 export interface TimeoutPollingHook<Response extends PollingEntity> {
   stopPolling: () => void;
@@ -52,7 +52,7 @@ export function useProjectTimeoutPolling<
   Entity extends PollingEntity,
   Response extends PollingResponse<Entity[]>
 >(props: UseTimeoutPollingProps<Entity, Response>): TimeoutPollingHook<Entity> {
-  const { isInitialLoad, error: initialLoadError } = useIsInitialLoad();
+  const { isInitialLoad, error: initialLoadError } = useGatewayStatus();
 
   const timeoutPollingState = useTimeoutPolling<Entity, Response>({
     ...props,

--- a/frontend/src/hooks/use-api.ts
+++ b/frontend/src/hooks/use-api.ts
@@ -257,9 +257,7 @@ export function useGatewayStatus(): {
 } {
   const [error, setError] = useState<FlowserError | undefined>();
   const [isInitialLoad, setIsInitialLoad] = useState(true);
-  const { data } = useGetProjectStatus({
-    refetchInterval: 1000,
-  });
+  const { data } = useGetProjectStatus();
 
   useEffect(() => {
     if (isInitialLoad) {
@@ -268,7 +266,7 @@ export function useGatewayStatus(): {
   }, [data]);
 
   useEffect(() => {
-    if (data?.gatewayStatus === ServiceStatus.SERVICE_STATUS_OFFLINE) {
+    if (data?.flowApiStatus === ServiceStatus.SERVICE_STATUS_OFFLINE) {
       setError({
         name: "Service Unreachable",
         message: "Gateway offline",
@@ -290,10 +288,11 @@ export function useGetProjectStatus(options?: {
   refetchInterval?: number;
   enabled?: boolean;
 }) {
+  const { refetchInterval = 1000, enabled = true } = options ?? {};
   return useQuery<GetProjectStatusResponse>(
     `/projects/status`,
     () => projectsService.getStatus(),
-    options
+    { refetchInterval, enabled }
   );
 }
 

--- a/frontend/src/hooks/use-api.ts
+++ b/frontend/src/hooks/use-api.ts
@@ -269,7 +269,7 @@ export function useGatewayStatus(): {
     if (data?.flowApiStatus === ServiceStatus.SERVICE_STATUS_OFFLINE) {
       setError({
         name: "Service Unreachable",
-        message: "Gateway offline",
+        message: "Flow API offline",
         description:
           "Can't reach Flow access node. Make sure Flow emulator is running without errors.",
       });

--- a/frontend/src/hooks/use-flow.ts
+++ b/frontend/src/hooks/use-flow.ts
@@ -97,12 +97,6 @@ export function useFlow() {
   async function login() {
     track(AnalyticEvent.CONNECT_WALLET);
 
-    if (!project?.devWallet?.run) {
-      // TODO(milestone-x): Check if wallet is online with GET {devWalletUrl}/api request
-      toast(
-        "Make sure you started the dev wallet with `flow dev-wallet` command"
-      );
-    }
     setLoggingIn(true);
     try {
       const result = await fcl.authenticate();

--- a/frontend/src/hooks/use-flow.ts
+++ b/frontend/src/hooks/use-flow.ts
@@ -4,10 +4,11 @@ import * as fcl from "@onflow/fcl";
 // @ts-ignore
 import * as t from "@onflow/types";
 import { toast } from "react-hot-toast";
-import { useGetCurrentProject } from "./use-api";
+import { useGetCurrentProject, useGetProjectStatus } from "./use-api";
 import { useQueryClient } from "react-query";
 import { useAnalytics } from "./use-analytics";
 import { AnalyticEvent } from "../services/analytics.service";
+import { ServiceStatus } from "@flowser/shared";
 
 export type FlowScriptArgumentValue = string | number;
 export type FlowScriptArgumentType = string;
@@ -35,6 +36,7 @@ export function setFclConfig(options: {
 export function useFlow() {
   const { track } = useAnalytics();
   const { data } = useGetCurrentProject();
+  const { data: projectStatus } = useGetProjectStatus();
   const { project } = data ?? {};
   const [user, setUser] = useState<{ loggedIn: null; addr?: string }>({
     loggedIn: null,
@@ -96,6 +98,15 @@ export function useFlow() {
 
   async function login() {
     track(AnalyticEvent.CONNECT_WALLET);
+
+    if (
+      projectStatus?.devWalletApiStatus !== ServiceStatus.SERVICE_STATUS_ONLINE
+    ) {
+      return toast.error(
+        `fcl-dev-wallet service doesn't appear to be running. 
+        Make sure to start it with \`flow dev-wallet\` command.`
+      );
+    }
 
     setLoggingIn(true);
     try {

--- a/frontend/src/pages/logs/Logs.tsx
+++ b/frontend/src/pages/logs/Logs.tsx
@@ -16,12 +16,13 @@ import CaretIcon from "../../components/caret-icon/CaretIcon";
 import { useSearch } from "../../hooks/use-search";
 import { useFilterData } from "../../hooks/use-filter-data";
 import { useMouseMove } from "../../hooks/use-mouse-move";
-import { useGetCurrentProject, useGetPollingLogs } from "../../hooks/use-api";
+import { useGetPollingLogs, useGetPollingProcesses } from "../../hooks/use-api";
 import { ManagedProcessLog, LogSource } from "@flowser/shared";
 import { toast } from "react-hot-toast";
 import classNames from "classnames";
 import { SimpleButton } from "../../components/simple-button/SimpleButton";
 import { TextUtils } from "../../utils/text-utils";
+import { CommonUtils } from "../../utils/common-utils";
 
 type LogsProps = {
   className?: string;
@@ -60,8 +61,12 @@ const Logs: FunctionComponent<LogsProps> = ({ className }) => {
     [logs]
   );
   const { searchTerm, setPlaceholder } = useSearch(SEARCH_CONTEXT_NAME);
-  const { data } = useGetCurrentProject();
-  const isCapturingEmulatorLogs = data?.project?.emulator?.run;
+  const { data: processes } = useGetPollingProcesses();
+  const isCapturingProcessLogs = processes.some(
+    (process) =>
+      CommonUtils.isEmulatorProcess(process) ||
+      CommonUtils.isDevWalletProcess(process)
+  );
   const { filteredData } = useFilterData(sortedLogs, searchTerm);
   const mouseEvent = useMouseMove(trackMousePosition);
 
@@ -134,8 +139,7 @@ const Logs: FunctionComponent<LogsProps> = ({ className }) => {
     setTrackMousePosition(false);
   }, []);
 
-  if (!isCapturingEmulatorLogs) {
-    // TODO(milestone-5): Should we show some kind of notice somewhere?
+  if (!isCapturingProcessLogs) {
     return null;
   }
 

--- a/frontend/src/pages/start/configuration/Configuration.tsx
+++ b/frontend/src/pages/start/configuration/Configuration.tsx
@@ -196,11 +196,6 @@ export const Configuration: FunctionComponent = () => {
             title="Dev wallet"
             collapseChildren
             className={classes.section}
-            isEnabled={formik.values.devWallet?.run}
-            onToggleEnabled={(isEnabled) =>
-              formik.setFieldValue("devWallet.run", isEnabled)
-            }
-            isToggleable
           >
             <Card className={classes.card}>
               <DevWalletTextField
@@ -215,11 +210,6 @@ export const Configuration: FunctionComponent = () => {
             title="Emulator"
             collapseChildren
             className={classes.section}
-            isEnabled={formik.values.emulator?.run}
-            onToggleEnabled={(isEnabled) =>
-              formik.setFieldValue("emulator.run", isEnabled)
-            }
-            isToggleable
           >
             <Card className={classes.card}>
               <EmulatorTextField

--- a/frontend/src/pages/start/configuration/Configuration.tsx
+++ b/frontend/src/pages/start/configuration/Configuration.tsx
@@ -194,6 +194,7 @@ export const Configuration: FunctionComponent = () => {
           </ConfigurationSection>
           <ConfigurationSection
             title="Dev wallet"
+            description="If fcl-dev-wallet is not running, Flowser will start it automatically."
             collapseChildren
             className={classes.section}
           >
@@ -208,6 +209,7 @@ export const Configuration: FunctionComponent = () => {
           </ConfigurationSection>
           <ConfigurationSection
             title="Emulator"
+            description="If flow-emulator is not running, Flowser will start it automatically."
             collapseChildren
             className={classes.section}
           >
@@ -385,7 +387,7 @@ export const Configuration: FunctionComponent = () => {
               href={`https://github.com/onflow/flow-cli/releases/tag/${flowCliInfo?.version}`}
               rel="noreferrer"
             >
-              Emulator version: {flowCliInfo?.version || "-"}
+              Flow CLI version {flowCliInfo?.version || "-"}
             </a>
           </div>
         </footer>

--- a/frontend/src/pages/start/configuration/ConfigurationSection.module.scss
+++ b/frontend/src/pages/start/configuration/ConfigurationSection.module.scss
@@ -13,6 +13,10 @@
         color: $light-grey;
         font-size: $font-size-big;
       }
+      .description {
+        color: $color-grey;
+        margin-left: $spacing-base;
+      }
       .toggleWrapper {
         display: flex;
         margin-left: $spacing-base;
@@ -26,23 +30,30 @@
     .rightSection {
       display: flex;
       align-items: center;
-      span {
+      .title {
         color: $color-grey;
         margin-right: $spacing-base;
-      }
-      .openIcon, .closeIcon {
-        width: 20px;
-        height: 20px;
-        cursor: pointer;
-      }
-      .openIcon {
-        path {
-          fill: $color-grey;
+        &:first-letter {
+          text-transform: uppercase;
         }
       }
-      .closeIcon {
-        path {
-          fill: $color-light-gray;
+      .toggleOpenButton {
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        .openIcon, .closeIcon {
+          width: 20px;
+          height: 20px;
+        }
+        .openIcon {
+          path {
+            fill: $color-grey;
+          }
+        }
+        .closeIcon {
+          path {
+            fill: $color-light-gray;
+          }
         }
       }
     }

--- a/frontend/src/pages/start/configuration/ConfigurationSection.tsx
+++ b/frontend/src/pages/start/configuration/ConfigurationSection.tsx
@@ -1,26 +1,20 @@
 import React, { FC, useState } from "react";
 import classes from "./ConfigurationSection.module.scss";
 import classNames from "classnames";
-import ToggleButton from "../../../components/toggle-button/ToggleButton";
 import { ReactComponent as OpenIcon } from "assets/icons/open.svg";
 import { ReactComponent as CloseIcon } from "assets/icons/close.svg";
 
 export type ConfigurationSectionProps = {
   title: string;
-  isToggleable?: boolean;
   className?: string;
   isEnabled?: boolean;
-  onToggleEnabled?: (isEnabled: boolean) => void;
   collapseChildren?: boolean;
 };
 
 export const ConfigurationSection: FC<ConfigurationSectionProps> = ({
   title,
-  isToggleable,
   children,
   className,
-  isEnabled,
-  onToggleEnabled,
   collapseChildren = false,
 }) => {
   const [showAdvanced, setShowAdvanced] = useState(!collapseChildren);
@@ -29,14 +23,6 @@ export const ConfigurationSection: FC<ConfigurationSectionProps> = ({
       <div className={classes.header}>
         <div className={classes.leftSection}>
           <h3 className={classes.title}>{title}</h3>
-          {isToggleable && (
-            <div className={classes.toggleWrapper}>
-              <ToggleButton
-                value={isEnabled}
-                onChange={(value) => onToggleEnabled?.(value)}
-              />
-            </div>
-          )}
         </div>
         <div className={classes.rightSection}>
           {collapseChildren && (

--- a/frontend/src/pages/start/configuration/ConfigurationSection.tsx
+++ b/frontend/src/pages/start/configuration/ConfigurationSection.tsx
@@ -6,6 +6,7 @@ import { ReactComponent as CloseIcon } from "assets/icons/close.svg";
 
 export type ConfigurationSectionProps = {
   title: string;
+  description?: string;
   className?: string;
   isEnabled?: boolean;
   collapseChildren?: boolean;
@@ -13,6 +14,7 @@ export type ConfigurationSectionProps = {
 
 export const ConfigurationSection: FC<ConfigurationSectionProps> = ({
   title,
+  description,
   children,
   className,
   collapseChildren = false,
@@ -23,23 +25,23 @@ export const ConfigurationSection: FC<ConfigurationSectionProps> = ({
       <div className={classes.header}>
         <div className={classes.leftSection}>
           <h3 className={classes.title}>{title}</h3>
+          {description && <p className={classes.description}>{description}</p>}
         </div>
         <div className={classes.rightSection}>
           {collapseChildren && (
-            <>
-              <span>Advanced settings</span>
+            <div
+              className={classes.toggleOpenButton}
+              onClick={() => setShowAdvanced((show) => !show)}
+            >
+              <span className={classes.title}>
+                {title.toLowerCase()} settings
+              </span>
               {showAdvanced ? (
-                <CloseIcon
-                  className={classes.closeIcon}
-                  onClick={() => setShowAdvanced(false)}
-                />
+                <CloseIcon className={classes.closeIcon} />
               ) : (
-                <OpenIcon
-                  className={classes.openIcon}
-                  onClick={() => setShowAdvanced(true)}
-                />
+                <OpenIcon className={classes.openIcon} />
               )}
-            </>
+            </div>
           )}
         </div>
       </div>

--- a/frontend/src/targets/electron/main.ts
+++ b/frontend/src/targets/electron/main.ts
@@ -5,7 +5,6 @@ import { SentryMainService } from "./services/sentry-main.service";
 import { setupMenu } from "./menu";
 import { ServiceRegistry } from "./services/service-registry";
 import { FlowserBackend } from "./backend";
-import { ProjectEntity } from "@flowser/backend";
 
 fixPath();
 
@@ -131,14 +130,6 @@ async function handleBackendStart() {
       project.filesystemPath = getSwitchValue(
         temporaryProjectFlags.projectPath
       );
-
-      // Do not run wallet/emulator, because Flow CLI will do it
-      if (project.emulator) {
-        project.emulator.run = false;
-      }
-      if (project.devWallet) {
-        project.devWallet.run = false;
-      }
 
       await backend.startTemporaryProject(project);
     }

--- a/frontend/src/utils/common-utils.ts
+++ b/frontend/src/utils/common-utils.ts
@@ -1,7 +1,15 @@
-import { FlowserError } from "@flowser/shared";
+import { FlowserError, ManagedProcess } from "@flowser/shared";
 import { DecoratedPollingEntity } from "contexts/timeout-polling.context";
 
 export class CommonUtils {
+  static isEmulatorProcess(process: ManagedProcess): boolean {
+    return process.id === "emulator";
+  }
+
+  static isDevWalletProcess(process: ManagedProcess): boolean {
+    return process.id === "dev-wallet";
+  }
+
   static isDecoratedPollingEntity<Entity>(
     entity: Entity
   ): entity is DecoratedPollingEntity<Entity> {

--- a/shared/proto/entities/common.proto
+++ b/shared/proto/entities/common.proto
@@ -18,3 +18,9 @@ enum HashAlgorithm {
   KMAC128_BLS_BLS12_381 = 5;
   KECCAK_256 = 6;
 }
+
+enum ServiceStatus {
+  SERVICE_STATUS_UNKNOWN = 0;
+  SERVICE_STATUS_ONLINE = 1;
+  SERVICE_STATUS_OFFLINE = 2;
+}

--- a/shared/proto/entities/projects.proto
+++ b/shared/proto/entities/projects.proto
@@ -40,12 +40,10 @@ message Gateway {
 }
 
 message DevWallet {
-  bool run = 1;
   int32 port = 2;
 }
 
 message Emulator {
-  bool run = 28;
   bool verbose_logging = 1;
   string log_format = 22;
   uint32 rest_server_port = 2;

--- a/shared/proto/entities/projects.proto
+++ b/shared/proto/entities/projects.proto
@@ -33,16 +33,10 @@ message Project {
   string updated_at = 9;
 }
 
-enum GatewayStatus {
-  GATEWAY_STATUS_UNKNOWN = 0;
-  GATEWAY_STATUS_ONLINE = 1;
-  GATEWAY_STATUS_OFFLINE = 2;
-}
-
 message Gateway {
   string rest_server_address = 1;
   string grpc_server_address = 2;
-  GatewayStatus status = 3;
+  ServiceStatus status = 3;
 }
 
 message DevWallet {

--- a/shared/proto/responses/projects.proto
+++ b/shared/proto/responses/projects.proto
@@ -12,7 +12,8 @@ message GetProjectRequirementsResponse {
 message GetProjectStatusResponse {
   // Number of blocks that our backend needs to process.
   uint32 total_blocks_to_process = 1;
-  ServiceStatus gateway_status = 2;
+  ServiceStatus flow_api_status = 2;
+  ServiceStatus dev_wallet_api_status = 3;
 }
 
 message GetAllProjectsResponse {

--- a/shared/proto/responses/projects.proto
+++ b/shared/proto/responses/projects.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 import "entities/projects.proto";
 import "entities/config.proto";
+import "entities/common.proto";
 import "responses/core.proto";
 
 message GetProjectRequirementsResponse {
@@ -11,7 +12,7 @@ message GetProjectRequirementsResponse {
 message GetProjectStatusResponse {
   // Number of blocks that our backend needs to process.
   uint32 total_blocks_to_process = 1;
-  GatewayStatus gateway_status = 2;
+  ServiceStatus gateway_status = 2;
 }
 
 message GetAllProjectsResponse {


### PR DESCRIPTION
**Changelist:**
- Better error handling for unreachable services (fcl-dev-wallet, emulator)
- Flowser now starts flow tools automatically if they are not already running (this also removes the need for a confusing toggle in project settings - see screenshot bellow)

<img width="1074" alt="Screenshot 2022-11-20 at 13 20 37" src="https://user-images.githubusercontent.com/36109955/202901540-4b70af74-fcf5-4d44-85da-e82e49837692.png">
