### PR TITLE
Change app name on windows

### DIFF
--- a/pkg/flowser/app.go
+++ b/pkg/flowser/app.go
@@ -120,14 +120,23 @@ func (a *App) unzip(source string, target string) error {
 
 // appDir returns the location of the executable application inside the installation dir.
 func (a *App) appDir(installDir string) (string, error) {
-	return path.Join(installDir, "Flowser.app"), nil
+	files := map[string]string{
+		darwin:  "Flowser.app",
+		windows: "@flowserapp",
+	}
+	executable, ok := files[runtime.GOOS]
+	if !ok {
+		return "", errorPlatformNotSupported
+	}
+
+	return path.Join(installDir, executable), nil
 }
 
 // executable returns the location of application executable.
 func (a *App) executable(installDir string) (string, error) {
 	files := map[string]string{
 		darwin:  "Contents/MacOS/Flowser",
-		windows: "@flowserapp",
+		windows: "Flowser.exe",
 	}
 	file, ok := files[runtime.GOOS]
 	if !ok {

--- a/pkg/flowser/app.go
+++ b/pkg/flowser/app.go
@@ -127,7 +127,7 @@ func (a *App) appDir(installDir string) (string, error) {
 func (a *App) executable(installDir string) (string, error) {
 	files := map[string]string{
 		darwin:  "Contents/MacOS/Flowser",
-		windows: "Flowser.exe",
+		windows: "@flowserapp",
 	}
 	file, ok := files[runtime.GOOS]
 	if !ok {


### PR DESCRIPTION
Change application name on Windows to match the one used by Flowser installer.