### PR TITLE
Wait on blockchain processing completion when polling

### DIFF
--- a/backend/src/core/async-interval-scheduler.ts
+++ b/backend/src/core/async-interval-scheduler.ts
@@ -1,0 +1,52 @@
+import { Logger } from "@nestjs/common";
+
+const logger = new Logger("Utils");
+
+export type ExecutableCallback = () => Promise<void>;
+
+export type AsyncIntervalOptions = {
+  functionToExecute: ExecutableCallback;
+  name: string;
+  intervalInMs: number;
+};
+
+/**
+ * Runs the provided function in interval.
+ * Waits for promise completion until rerunning interval.
+ */
+export class AsyncIntervalScheduler {
+  private isRunning: boolean;
+  private runningTimeoutId: NodeJS.Timeout;
+  private readonly options: AsyncIntervalOptions;
+
+  constructor(options: AsyncIntervalOptions) {
+    this.options = options;
+    this.isRunning = false;
+  }
+
+  async start(): Promise<void> {
+    this.isRunning = true;
+    await this.handler();
+  }
+
+  stop(): void {
+    this.isRunning = false;
+  }
+
+  private async handler() {
+    const { functionToExecute, name, intervalInMs } = this.options;
+    if (!this.isRunning) {
+      return;
+    }
+    try {
+      const startTime = new Date();
+      await functionToExecute();
+      const endTime = new Date();
+      const runTimeInMs = endTime.getTime() - startTime.getTime();
+      logger.debug(`${name} took ${runTimeInMs}ms`);
+    } catch (e) {
+      logger.error(`${name} failed`, e);
+    }
+    this.runningTimeoutId = setTimeout(this.handler.bind(this), intervalInMs);
+  }
+}

--- a/backend/src/core/async-interval-scheduler.ts
+++ b/backend/src/core/async-interval-scheduler.ts
@@ -43,7 +43,9 @@ export class AsyncIntervalScheduler {
       await functionToExecute();
       const endTime = new Date();
       const runTimeInMs = endTime.getTime() - startTime.getTime();
-      logger.debug(`${name} took ${runTimeInMs}ms`);
+      if (runTimeInMs > intervalInMs) {
+        logger.debug(`${name} took ${runTimeInMs}ms`);
+      }
     } catch (e) {
       logger.error(`${name} failed`, e);
     }

--- a/backend/src/flow/services/aggregator.service.ts
+++ b/backend/src/flow/services/aggregator.service.ts
@@ -81,7 +81,7 @@ export class FlowAggregatorService
   private projectContext: ProjectEntity | undefined;
   private emulatorProcess: ManagedProcessEntity | undefined;
   private readonly logger = new Logger(FlowAggregatorService.name);
-  private readonly processingIntervalMs = 1000;
+  private readonly processingIntervalMs = 500;
   private processingScheduler: AsyncIntervalScheduler | undefined;
 
   constructor(


### PR DESCRIPTION
Previously we ran our blockchain processing function every second, regardless if the previous run was completed or not.

This causes problems if there is a larger amount of data to be processed - processing takes more than a second.