### PR TITLE
Fix log drawer performance

### DIFF
--- a/backend/src/flow/services/emulator.service.ts
+++ b/backend/src/flow/services/emulator.service.ts
@@ -109,9 +109,9 @@ export class FlowEmulatorService implements ProjectContextLifecycle {
     // Some default values vary from the ones used in Flow CLI.
     return {
       verboseLogging: true,
-      enableRestDebug: true,
+      enableRestDebug: false,
       restServerPort: 8888,
-      enableGrpcDebug: true,
+      enableGrpcDebug: false,
       grpcServerPort: 3569,
       adminServerPort: 8080,
       persist: false,

--- a/frontend/src/hooks/use-filter-data.ts
+++ b/frontend/src/hooks/use-filter-data.ts
@@ -4,7 +4,7 @@ export interface UseFilterDataHook<T> {
 
 export const useFilterData = <T>(
   data: T[],
-  search: string,
+  searchTerm: string | undefined,
   filterByProps?: string[]
 ): UseFilterDataHook<T[]> => {
   if (!Array.isArray(data) || data.length === 0) {
@@ -12,11 +12,13 @@ export const useFilterData = <T>(
   }
 
   filterByProps = filterByProps || Object.keys(data[0] as never);
-  const filteredData = data.filter(
-    (item) =>
-      JSON.stringify(item, filterByProps)
-        .toLocaleLowerCase()
-        .indexOf(search.toLocaleLowerCase().toString()) !== -1
-  );
+  const filteredData = searchTerm
+    ? data.filter(
+        (item) =>
+          JSON.stringify(item, filterByProps)
+            .toLocaleLowerCase()
+            .indexOf(searchTerm.toLocaleLowerCase().toString()) !== -1
+      )
+    : data;
   return { filteredData };
 };


### PR DESCRIPTION
When there are larger number of logs (e.g. when http debug or grcp debug flags are set), the whole client app performance suffers, due to frequent re-renders of larger logs list in logs drawer (even when collapsed).

To fix that, we limit the logs to render on collapsed view to just a few recent logs and set debug http/grcp to false by default.