### PR TITLE
Fix snapshot flag usage

### DIFF
--- a/packages/nodejs/src/flow-emulator.service.ts
+++ b/packages/nodejs/src/flow-emulator.service.ts
@@ -154,10 +154,7 @@ export class FlowEmulatorService extends EventEmitter {
       flag("service-hash-algo", config.serviceHashAlgorithm),
       flag("rest-debug", config.enableRestDebug),
       flag("grpc-debug", config.enableGrpcDebug),
-      // Automatically enable persistence when snapshot option is used.
-      // Only required until below flow-emulator issue is resolved:
-      // https://github.com/onflow/flow-emulator/issues/490
-      flag("persist", config.persist || config.snapshot),
+      flag("persist", config.persist),
       flag("snapshot", config.snapshot),
       flag("dbpath", config.databasePath),
       flag("simple-addresses", config.useSimpleAddresses),

--- a/packages/ui/src/workspaces/WorkspaceSettings/WorkspaceSettings.tsx
+++ b/packages/ui/src/workspaces/WorkspaceSettings/WorkspaceSettings.tsx
@@ -292,13 +292,13 @@ export const WorkspaceSettings: FunctionComponent<ProjectSettingsProps> = (
               <EmulatorToggleField
                 label="Persist"
                 path="persist"
-                description="Persist emaulator blockchain state between restarts"
+                description="Persist blockchain state between restarts"
                 formik={formik}
               />
               <EmulatorToggleField
                 label="Snapshots"
                 path="snapshot"
-                description="Enable blockchain state snapshots (this option automatically enables persistence)"
+                description="Enable blockchain state snapshots"
                 formik={formik}
               />
               <EmulatorToggleField


### PR DESCRIPTION
We don't need to use `--persist` flag when `--snapshot` flag is used, as explained here: https://github.com/onflow/flow-emulator/issues/490