### PR TITLE
FLIX audit info

### DIFF
--- a/packages/ui/src/hooks/flix.ts
+++ b/packages/ui/src/hooks/flix.ts
@@ -13,6 +13,16 @@ export type FlixTemplate = {
   };
 };
 
+export type FlixAuditor = {
+  f_type: "FlowInteractionTemplateAuditor";
+  f_version: string;
+  address: string;
+  name: string;
+  twitter_url: string;
+  website_url: string;
+}
+
+
 export type FlixArgument = {
   index: number;
   type: string;
@@ -46,7 +56,7 @@ type FlixI18nMessage = {
 };
 
 export const FLOW_FLIX_URL = "https://flix.flow.com";
-export const FLOWSER_FLIX_URL = "https://flowser-flix-368a32c94da2.herokuapp.com"
+export const FLOWSER_FLIX_URL = "http://localhost:3333"
 
 export function useListFlixTemplates(): SWRResponse<FlixTemplate[]> {
   return useSWR(`flix/templates`, () =>
@@ -71,6 +81,20 @@ export function useFlixSearch(options: {
         network: options.network
       })
     }).then((res) => res.json()),
+    {
+      refreshInterval: 0,
+      shouldRetryOnError: false
+    }
+  );
+}
+
+export function useFlixTemplateAuditors(options: {
+  templateId: string;
+  network: "testnet" | "mainnet";
+}): SWRResponse<FlixAuditor[]> {
+  return useSWR(`flix/${options.network}/templates/${options.templateId}/auditors`, () =>
+      fetch(`${FLOWSER_FLIX_URL}/v1/templates/${options.templateId}/auditors?network=${options.network}`)
+        .then((res) => res.json()),
     {
       refreshInterval: 0,
       shouldRetryOnError: false

--- a/packages/ui/src/hooks/flix.ts
+++ b/packages/ui/src/hooks/flix.ts
@@ -56,7 +56,7 @@ type FlixI18nMessage = {
 };
 
 export const FLOW_FLIX_URL = "https://flix.flow.com";
-export const FLOWSER_FLIX_URL = "http://localhost:3333"
+export const FLOWSER_FLIX_URL = "https://flowser-flix-368a32c94da2.herokuapp.com";
 
 export function useListFlixTemplates(): SWRResponse<FlixTemplate[]> {
   return useSWR(`flix/templates`, () =>

--- a/packages/ui/src/interactions/components/FlixInfo/FlixInfo.module.scss
+++ b/packages/ui/src/interactions/components/FlixInfo/FlixInfo.module.scss
@@ -32,11 +32,5 @@
     display: flex;
     flex-direction: column;
     row-gap: $spacing-base;
-
-    .auditorList {
-      display: flex;
-      flex-direction: row;
-      column-gap: $spacing-s;
-    }
   }
 }

--- a/packages/ui/src/interactions/components/FlixInfo/FlixInfo.module.scss
+++ b/packages/ui/src/interactions/components/FlixInfo/FlixInfo.module.scss
@@ -32,5 +32,11 @@
     display: flex;
     flex-direction: column;
     row-gap: $spacing-base;
+
+    .auditorList {
+      display: flex;
+      flex-direction: row;
+      column-gap: $spacing-s;
+    }
   }
 }

--- a/packages/ui/src/interactions/components/FlixInfo/FlixInfo.tsx
+++ b/packages/ui/src/interactions/components/FlixInfo/FlixInfo.tsx
@@ -1,4 +1,4 @@
-import { FLOW_FLIX_URL, useFlixSearch } from "../../../hooks/flix";
+import { FlixAuditor, FLOW_FLIX_URL, useFlixSearch, useFlixTemplateAuditors } from "../../../hooks/flix";
 import { Shimmer } from "../../../common/loaders/Shimmer/Shimmer";
 import classes from "./FlixInfo.module.scss";
 import { ExternalLink } from "../../../common/links/ExternalLink/ExternalLink";
@@ -44,6 +44,7 @@ export function FlixInfo(props: FlixInfoProps) {
       <div className={classes.body}>
         {isVerified ? (
           <Fragment>
+            <AuditInfo templateId={data.id} />
             <p>{data.data.messages.description?.i18n["en-US"]}</p>
             <ExternalLink inline href={`${FLOW_FLIX_URL}/v1/templates/${data.id}`} />
           </Fragment>
@@ -63,4 +64,34 @@ export function FlixInfo(props: FlixInfoProps) {
       </div>
     </div>
   );
+}
+
+function AuditInfo(props: {templateId: string}) {
+  const {data} = useFlixTemplateAuditors({
+    templateId: props.templateId,
+    // Use mainnet for now, as mainnet likely has the most audits.
+    network: "mainnet"
+  });
+
+  if (!data) {
+    return <Shimmer height={50} />;
+  }
+
+  if (data.length === 0) {
+    // FLIX templates are treated as being more trustworthy/verified,
+    // even if no official audits were performed.
+    // For now just ignore the case where no audits exist.
+    return null;
+  }
+
+  return (
+    <div className={classes.auditorList}>
+      Audited by:
+      {data.map((auditor, index) =>
+        <ExternalLink href={auditor.twitter_url} inline>
+          {auditor.name}{index + 1 < data.length ? "," : ""}
+        </ExternalLink>
+      )}
+    </div>
+  )
 }

--- a/packages/ui/src/interactions/components/FlixInfo/FlixInfo.tsx
+++ b/packages/ui/src/interactions/components/FlixInfo/FlixInfo.tsx
@@ -85,11 +85,11 @@ function AuditInfo(props: {templateId: string}) {
   }
 
   return (
-    <div className={classes.auditorList}>
+    <div>
       Audited by:
-      {data.map((auditor, index) =>
+      {data.map((auditor) =>
         <ExternalLink href={auditor.twitter_url} inline>
-          {auditor.name}{index + 1 < data.length ? "," : ""}
+          {auditor.name}
         </ExternalLink>
       )}
     </div>


### PR DESCRIPTION
Display FLIX auditors (if applicable).

![Screenshot 2023-12-18 at 12 23 54](https://github.com/onflowser/flowser/assets/36109955/912ed20d-c677-4bc6-97b2-2276f6d5c77d)

This consumes the newly added (experimental) audits API: https://github.com/onflowser/flow-interaction-template-service/pull/6
