### PR TITLE
Fix default values for initial interaction

### DIFF
--- a/packages/ui/src/interactions/components/ExecutionSettings/ExecutionSettings.tsx
+++ b/packages/ui/src/interactions/components/ExecutionSettings/ExecutionSettings.tsx
@@ -219,6 +219,7 @@ function SigningSettings() {
       <h2>Signing</h2>
       <SizedBox height={20} />
       <ParamBuilder
+        flixArgument={undefined}
         parameter={{
           identifier: "Proposer",
           type: {
@@ -238,6 +239,7 @@ function SigningSettings() {
       />
       <SizedBox height={12} />
       <ParamBuilder
+        flixArgument={undefined}
         parameter={{
           identifier: "Payer",
           type: {

--- a/packages/ui/src/interactions/contexts/definition.context.tsx
+++ b/packages/ui/src/interactions/contexts/definition.context.tsx
@@ -61,7 +61,7 @@ export function InteractionDefinitionManagerProvider(props: {
     <Context.Provider
       value={{
         definition,
-        flixTemplate,
+        flixTemplate: flixTemplate ?? undefined,
         parsedInteraction: data?.interaction,
         partialUpdate,
         setFclValue,

--- a/packages/ui/src/interactions/contexts/interaction-registry.context.tsx
+++ b/packages/ui/src/interactions/contexts/interaction-registry.context.tsx
@@ -46,8 +46,8 @@ export function InteractionRegistryProvider(props: {
     initialOutcome: undefined,
     transactionOptions: {
       authorizerAddresses: [],
-      proposerAddress: "0xf8d6e0586b0a20c7",
-      payerAddress: "0xf8d6e0586b0a20c7",
+      proposerAddress: "",
+      payerAddress: "",
     },
     createdDate: new Date(),
     updatedDate: new Date(),

--- a/packages/ui/src/interactions/contexts/interaction-registry.context.tsx
+++ b/packages/ui/src/interactions/contexts/interaction-registry.context.tsx
@@ -40,7 +40,7 @@ export function InteractionRegistryProvider(props: {
 }): ReactElement {
   const defaultInteraction: InteractionDefinition = {
     id: crypto.randomUUID(),
-    name: "Your first interaction",
+    name: "New interaction",
     code: "",
     fclValuesByIdentifier: new Map(),
     initialOutcome: undefined,


### PR DESCRIPTION
It's not always the case that we know the private keys of service account (e.g. if not available in flow.json), so we must not use these default values.